### PR TITLE
Import Pluton workspace

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -160,6 +160,13 @@ This project uses [npm workspaces](https://docs.npmjs.com/cli/using-npm/workspac
 
 Inside this project there are PostCSS plugins, the core library, and the dev documentation.
 
+### Historical Workspaces
+
+[`pluton.css`](./pluton.css) is preserved here as the lightweight subset that
+split from Obsidian.css before the project became Layr. It keeps its historical
+source API and builds with the same current PostCSS toolchain as the rest of the
+monorepo.
+
 ### Issues
 
 **Reduced test cases are required**. All bug reports and problem issues require a reduced test case. See [CSS Tricks - Reduced Test Cases](http://css-tricks.com/reduced-test-cases/) on why they _"are the absolute, ... number one way to troubleshoot bugs."_ Reduced test cases help you identify the issue at hand and understand your own code. On our side, they greatly reduce the amount of time spent resolving the issue.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "modern-parker",
         "postcss-parker",
         "layr.css",
+        "pluton.css",
         "documentation",
         "sass-port"
       ],
@@ -8256,6 +8257,10 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pluton.css": {
+      "resolved": "pluton.css",
+      "link": true
+    },
     "node_modules/postcss": {
       "version": "8.5.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
@@ -11275,6 +11280,19 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "pluton.css": {
+      "version": "1.1.3",
+      "license": "MIT",
+      "devDependencies": {
+        "autoprefixer": "^10.5.4",
+        "cssnano": "^8.0.2",
+        "del-cli": "^7.0.0",
+        "postcss": "^8.5.23",
+        "postcss-cli": "^11.0.1",
+        "postcss-import": "^16.1.1",
+        "stylelint": "^17.14.1"
       }
     },
     "sass-port": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "modern-parker",
     "postcss-parker",
     "layr.css",
+    "pluton.css",
     "documentation",
     "sass-port"
   ],

--- a/pluton.css/Readme.md
+++ b/pluton.css/Readme.md
@@ -1,0 +1,35 @@
+# Pluton
+
+Pluton is the historical lightweight subset of Obsidian.css. It contains the
+shared settings, reset, elements, core objects, and utility classes without the
+full component layer that later became Layr.
+
+The source at standalone commit
+[`1610037`](https://github.com/charliewilco/pluton.css/commit/1610037b8eaf239d21787a993f60c555ac0be34d)
+was moved from
+[`charliewilco/pluton.css`](https://github.com/charliewilco/pluton.css) into the
+Layr monorepo so the related implementations can be built and inspected
+together. This workspace preserves the published `pluton.css@1.1.3` source API,
+but it is not currently intended for npm republishing.
+
+## Build
+
+From the Layr repository root:
+
+```sh
+npm install
+npm run build --workspace pluton.css
+```
+
+## Usage
+
+```css
+@import "pluton.css";
+
+/* Or import individual layers. */
+@import "pluton.css/settings";
+@import "pluton.css/generic";
+@import "pluton.css/elements";
+@import "pluton.css/objects";
+@import "pluton.css/utilities";
+```

--- a/pluton.css/elements.css
+++ b/pluton.css/elements.css
@@ -1,0 +1,276 @@
+
+/*
+  ELEMENTS - Reset and Responsive / Extended Styling
+
+  Forms............Form Resets.
+  Headlines........H1–H6 sizes.
+  Body Text........Paragraphs.
+  Images...........Default for SVG and Images.
+  Lists............Default Listing and Reset.
+  Links............Anchors and Link Classes.
+*/
+
+/*----------Table Element----------*/
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}
+
+/*----------Form Reset & Form Default Elements----------*/
+
+/* All Defaults */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  background: inherit;
+  color: inherit;
+  box-sizing: inherit;
+  line-height: inherit;
+  font-family: inherit;
+  font-size: 100%;
+  margin: 0;
+}
+
+button[disabled],
+input[disabled] {
+  cursor: default;
+}
+
+/* Input Fields */
+
+input[type='search'],
+input[type='text'],
+input[type='number'],
+input[type='email'],
+input[type='password'] {
+  appearance: none;
+}
+
+/* Textareas */
+
+textarea {
+  overflow: auto;
+}
+
+/* Selects */
+
+select { appearance: menulist; }
+
+optgroup { font-weight: bold; }
+
+/* Buttons & Submissions */
+
+button { overflow: visible; }
+
+button,
+input[type='button'],
+input[type='reset'],
+input[type='submit'] {
+  cursor: pointer;
+  appearance: none;
+}
+
+/* Other */
+
+fieldset {
+  border: 1px solid;
+  margin: 0;
+  padding: calc(var(--base-spacing) / 4);
+}
+
+legend {
+  border: 0;
+  padding: 0;
+}
+
+/*----------Headline Elements----------*/
+
+/*
+  NOTE: Originally based off the Golden Ratio and 1rem being modified at each break point
+*/
+
+/* Sizes */
+
+:root {
+  /* Line Heights */
+  --lh-1: 1.125;
+  --lh-2: 1.25;
+  --lh-3: 1.5;
+
+  /* Multipliers */
+  --sm-multiplier: .875;
+  --md-multiplier: 1;
+  --lg-multiplier: 1.125;
+
+  /* Headline Sizes */
+  --headline-1: 3.125rem;
+  --headline-2: 2.5rem;
+  --headline-3: 2.125rem;
+  --headline-4: 1.75rem;
+  --headline-5: 1.5rem;
+  --headline-6: 1.25rem;
+
+  /* Headline Small Sizes */
+  --headline-1-sm: calc(var(--headline-1) * var(--sm-multiplier));
+  --headline-2-sm: calc(var(--headline-2) * var(--sm-multiplier));
+  --headline-3-sm: calc(var(--headline-3) * var(--sm-multiplier));
+  --headline-4-sm: calc(var(--headline-4) * var(--sm-multiplier));
+  --headline-5-sm: calc(var(--headline-5) * var(--sm-multiplier));
+  --headline-6-sm: calc(var(--headline-6) * var(--sm-multiplier));
+
+  /* Headline Medium Sizes */
+  --headline-1-md: calc(var(--headline-1) * var(--md-multiplier));
+  --headline-2-md: calc(var(--headline-2) * var(--md-multiplier));
+  --headline-3-md: calc(var(--headline-3) * var(--md-multiplier));
+  --headline-4-md: calc(var(--headline-4) * var(--md-multiplier));
+  --headline-5-md: calc(var(--headline-5) * var(--md-multiplier));
+  --headline-6-md: calc(var(--headline-6) * var(--md-multiplier));
+
+  /* Headline Large Sizes */
+  --headline-1-lg: calc(var(--headline-1) * var(--lg-multiplier));
+  --headline-2-lg: calc(var(--headline-2) * var(--lg-multiplier));
+  --headline-3-lg: calc(var(--headline-3) * var(--lg-multiplier));
+  --headline-4-lg: calc(var(--headline-4) * var(--lg-multiplier));
+  --headline-5-lg: calc(var(--headline-5) * var(--lg-multiplier));
+  --headline-6-lg: calc(var(--headline-6) * var(--lg-multiplier));
+}
+
+h1,
+.h1 { font-size: var(--headline-1-sm); }
+
+h2,
+.h2 { font-size: var(--headline-2-sm); }
+
+h3,
+.h3 { font-size: var(--headline-3-sm); }
+
+h4,
+.h4 { font-size: var(--headline-4-sm); }
+
+h5,
+.h5 { font-size: var(--headline-5-sm); }
+
+h6,
+.h6 { font-size: var(--headline-6-sm); }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  margin: 0;
+  line-height: var(--lh-3);
+  font-family: var(--headlines);
+}
+
+@media only screen and (min-width: 48rem) {
+  h1,
+  .h1 { font-size: var(--headline-1-md); }
+
+  h2,
+  .h2 { font-size: var(--headline-2-md); }
+
+  h3,
+  .h3 { font-size: var(--headline-3-md); }
+
+  h4,
+  .h4 { font-size: var(--headline-4-md); }
+
+  h5,
+  .h5 { font-size: var(--headline-5-md); }
+
+  h6,
+  .h6 { font-size: var(--headline-6-md); }
+}
+
+@media only screen and (min-width: 57.75rem) {
+  h1,
+  .h1 { font-size: var(--headline-1-lg); }
+
+  h2,
+  .h2 { font-size: var(--headline-2-lg); }
+
+  h3,
+  .h3 { font-size: var(--headline-3-lg); }
+
+  h4,
+  .h4 { font-size: var(--headline-4-lg); }
+
+  h5,
+  .h5 { font-size: var(--headline-5-lg); }
+
+  h6,
+  .h6 { font-size: var(--headline-6-lg); }
+}
+
+.small { font-size: 87.5%; }
+
+/*----------Body Text Default Elements----------*/
+
+p {
+  font-family: var(--body-text);
+}
+
+p:not(:last-of-type) {
+  margin-bottom: var(--base-spacing);
+}
+
+/*----------Image Element----------*/
+
+img {
+  max-width: 100%;
+  font-style: italic;
+  vertical-align: middle;
+  border: 0;
+}
+
+svg:not(:root) { overflow: hidden; }
+
+svg {
+  fill: currentColor;
+  pointer-events: none;
+  max-height: 100%;
+}
+
+/*----------List & List Item Elements---------*/
+
+li > ul,
+li > ol { margin-bottom: 0; }
+
+ul,
+ol { list-style-position: inside; }
+
+/*---------Link Defaults / Anchor Element----------*/
+
+:root {
+  --link: var(--color-1);
+  --link-hover: var(--blue-light);
+}
+
+a {
+  background-color: transparent;
+  text-decoration: none;
+  color: var(--link);
+}
+
+a:active,
+a:hover {
+  color: var(--link-hover);
+  outline: 0;
+}

--- a/pluton.css/generic.css
+++ b/pluton.css/generic.css
@@ -1,0 +1,102 @@
+/*
+  GENERIC - Reset
+
+  Reset............Modified / Stripped Down Normalize.
+*/
+
+/*---------Reset----------*/
+
+/*
+  NOTE: Modified from Jonathan Neal and Nicolas Gallagher's normalize.css
+*/
+
+/* Base Reset */
+
+* {
+  margin: 0;
+  padding: 0;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+html {
+  box-sizing: border-box;
+  text-size-adjust: 100%;
+  font: var(--ff-w) var(--ff-init-size) / var(--lh) var(--default);
+  -webkit-tap-highlight-color: transparent;
+  color: var(--text);
+}
+
+article,
+aside,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section {
+  display: block;
+}
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Media */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+  vertical-align: baseline;
+}
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/* Text Selectors */
+
+abbr[title] {
+  border-bottom-width: calc(var(--base-border) / 2);
+  border-bottom-style: dotted;
+}
+
+b,
+strong {
+  font-weight: bold;
+}
+
+i,
+em {
+  font-style: italic;
+}
+
+/* Content */
+
+figure { margin: 0; }
+
+hr {
+  border: 0;
+  height: var(--base-border);
+}
+
+/* Code Blocks */
+
+pre { overflow: auto; }
+
+code,
+pre {
+  font-family: var(--ff-mono);
+  font-size: 100%;
+}

--- a/pluton.css/index.css
+++ b/pluton.css/index.css
@@ -1,0 +1,9 @@
+/*!----------------------------------------------------\
+    Pluton.css v1 MIT obsidian.charlespeters.net
+\----------------------------------------------------!*/
+
+@import './settings';
+@import './generic';
+@import './elements';
+@import './objects';
+@import './utilities';

--- a/pluton.css/objects.css
+++ b/pluton.css/objects.css
@@ -1,0 +1,339 @@
+/*
+  OBJECTS - Unstyled skeleton design patterns
+
+  Container......Page Wrapper.
+  Grid...........Grid Parent and Responsive Columns.
+  Intrinsic......Intrinsic Object.
+  Flex...........Flex Container, Children & Modifies.
+  Media Object...Media Object Pattern with implemented with flexbox
+  Flag Object....More adaptable media object
+*/
+
+
+/*----------Containers / Wrapper Object----------*/
+
+:root {
+  --container-lg: calc(var(--base-container) * .75);
+  --container-md: calc(var(--base-container) * .625);
+  --container-sm: calc(var(--base-container) * .5);
+  --container-xs: calc(var(--base-container) * .375);
+}
+
+.Container,
+.Container--full { max-width: var(--base-container); }
+.Container--lg   { max-width: var(--container-lg); }
+.Container--md   { max-width: var(--container-md); }
+.Container--sm   { max-width: var(--container-sm); }
+.Container--xs   { max-width: var(--container-xs); }
+
+.Container--center {
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+
+/*----------Grid Object----------*/
+
+:root {
+  --col-1: calc((1/12) * 100%);
+  --col-2: calc((2/12) * 100%);
+  --col-3: calc((3/12) * 100%);
+  --col-4: calc((4/12) * 100%);
+  --col-5: calc((5/12) * 100%);
+  --col-6: calc((6/12) * 100%);
+  --col-7: calc((7/12) * 100%);
+  --col-8: calc((8/12) * 100%);
+  --col-9: calc((9/12) * 100%);
+  --col-10: calc((10/12) * 100%);
+  --col-11: calc((11/12) * 100%);
+  --col-12: calc((12/12) * 100%);
+}
+
+[class*='o-Column--'] { max-width: 100%; }
+
+.Column {
+  float: left;
+  position: relative;
+  min-height: 1px;
+}
+
+.Column--1\/12 { width: var(--col-1); }
+.Column--2\/12 { width: var(--col-2); }
+.Column--3\/12 { width: var(--col-3); }
+.Column--4\/12 { width: var(--col-4); }
+.Column--5\/12 { width: var(--col-5); }
+.Column--6\/12 { width: var(--col-6); }
+.Column--7\/12 { width: var(--col-7); }
+.Column--8\/12 { width: var(--col-8); }
+.Column--9\/12 { width: var(--col-9); }
+.Column--10\/12 { width: var(--col-10); }
+.Column--11\/12 { width: var(--col-11); }
+.Column--12\/12 { width: var(--col-12); }
+
+@media only screen and (min-width: 31.25rem) {
+  .Column\@sm {
+    float: left;
+    position: relative;
+    min-height: 1px;
+  }
+
+  .Column--1\/12\@sm { width: var(--col-1); }
+  .Column--2\/12\@sm { width: var(--col-2); }
+  .Column--3\/12\@sm { width: var(--col-3); }
+  .Column--4\/12\@sm { width: var(--col-4); }
+  .Column--5\/12\@sm { width: var(--col-5); }
+  .Column--6\/12\@sm { width: var(--col-6); }
+  .Column--7\/12\@sm { width: var(--col-7); }
+  .Column--8\/12\@sm { width: var(--col-8); }
+  .Column--9\/12\@sm { width: var(--col-9); }
+  .Column--10\/12\@sm { width: var(--col-10); }
+  .Column--11\/12\@sm { width: var(--col-11); }
+  .Column--12\/12\@sm { width: var(--col-12); }
+}
+
+@media only screen and (min-width: 48rem) {
+  .Column\@md {
+    float: left;
+    position: relative;
+    min-height: 1px;
+  }
+
+  .Column--1\/12\@md { width: var(--col-1); }
+  .Column--2\/12\@md { width: var(--col-2); }
+  .Column--3\/12\@md { width: var(--col-3); }
+  .Column--4\/12\@md { width: var(--col-4); }
+  .Column--5\/12\@md { width: var(--col-5); }
+  .Column--6\/12\@md { width: var(--col-6); }
+  .Column--7\/12\@md { width: var(--col-7); }
+  .Column--8\/12\@md { width: var(--col-8); }
+  .Column--9\/12\@md { width: var(--col-9); }
+  .Column--10\/12\@md { width: var(--col-10); }
+  .Column--11\/12\@md { width: var(--col-11); }
+  .Column--12\/12\@md { width: var(--col-12); }
+}
+
+@media only screen and (min-width: 57.75rem) {
+  .Column\@lg {
+    float: left;
+    position: relative;
+    min-height: 1px;
+  }
+
+  .Column--1\/12\@lg { width: var(--col-1); }
+  .Column--2\/12\@lg { width: var(--col-2); }
+  .Column--3\/12\@lg { width: var(--col-3); }
+  .Column--4\/12\@lg { width: var(--col-4); }
+  .Column--5\/12\@lg { width: var(--col-5); }
+  .Column--6\/12\@lg { width: var(--col-6); }
+  .Column--7\/12\@lg { width: var(--col-7); }
+  .Column--8\/12\@lg { width: var(--col-8); }
+  .Column--9\/12\@lg { width: var(--col-9); }
+  .Column--10\/12\@lg { width: var(--col-10); }
+  .Column--11\/12\@lg { width: var(--col-11); }
+  .Column--12\/12\@lg { width: var(--col-12); }
+}
+
+/*--------UI List Object----------*/
+
+:root {
+  --UIList-border: #CCC;
+  --UIList-space: .5rem;
+}
+
+.UIList {
+  list-style: inside none;
+  margin: 0;
+  padding: 0;
+}
+
+.UIList--dividers > .UIList__item:not(:last-of-type) {
+  border-bottom: 1px solid var(--UIList-border);
+}
+
+.UIList--inline > .UIList__item { display: inline-block; }
+
+.UIList__item { padding: .5rem 0; padding: var(--UIList-space) 0; }
+
+/*----------Intrinsic Ratio Container Object----------*/
+
+/*
+  NOTE: Based off of 'Intrinsic Placeholders with the Picture Element'
+  http://daverupert.com/2015/12/intrinsic-placeholders-with-picture/
+*/
+
+.Intrinsic {
+  display: block;
+  position: relative;
+  height: 0;
+  width: 100%;
+  padding-top: 100%;
+}
+
+.Intrinsic__item {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+}
+
+/* Intrinsic Sizes */
+
+.Intrinsic--square { padding-top: 100%; }
+.Intrinsic--4x3 { padding-top: 75%; }
+.Intrinsic--16x9 { padding-top: 56.25%; }
+.Intrinsic--3x1 { padding-top: 33.33333333%; }
+
+/*----------Flex Object----------*/
+
+.Flex { display: flex; }
+
+/* Wrap */
+
+.Flex--wrap { flex-wrap: wrap; }
+
+/* Centering */
+
+.Flex--center--h { align-items: center; }
+
+.Flex--center--v {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+/* Direction */
+
+.Flex--row { flex-direction: row; }
+.Flex--column { flex-direction: column; }
+
+/* Justified Content */
+
+.Flex--j--sb,
+.Flex--between {
+  justify-content: space-between;
+}
+
+.Flex--j--sa,
+.Flex--around {
+  justify-content: space-around;
+}
+
+.Flex--j--c,
+.Flex--center {
+  justify-content: center;
+}
+
+/* Ordering Flex Objects */
+
+.Flex--first { order: 1; }
+.Flex--last { order: unset; }
+
+/*
+  NOTE: The flex child element needs an explicit width & min-height
+  for bugs related to Safari 9 and Chrome 44
+*/
+
+.Flex__child {
+  display: initial;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  width: auto;
+}
+
+/*--------Media Block Object----------*/
+
+/*
+  NOTE: This is a Flexbox implementation of the Media Object from Nicole Sullivan
+  from Solved by Flexbox by Philip Walton
+  https://philipwalton.github.io/solved-by-flexbox/demos/media-object/
+*/
+
+:root {
+  --media-figure: 6.25rem;
+  --media-figure-sm: calc(var(--media-figure) * .75);
+}
+
+.Media {
+  display: flex;
+  align-items: flex-start;
+}
+
+.Media__figure {
+  max-width: var(--media-figure-sm);
+}
+
+.Media__body { flex: 1; }
+
+@media only screen and (min-width: 48rem) {
+  .Media__figure {
+    max-width: var(--media-figure);
+  }
+}
+
+/*---------Flag Object----------*/
+
+/*
+  NOTE: From 'The flag object' from Harry Roberts
+  http://csswizardry.com/2013/05/the-flag-object/
+*/
+
+.Flag {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.Flag--top { align-items: flex-start; }
+.Flag--bottom { align-items: flex-end; }
+.Flag--reverse { flex-direction: row-reverse; }
+
+.Flag__figure,
+.Flag__body {
+  display: initial;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.Flag__figure { flex: 1 1 auto; }
+
+.Flag__body { flex: 4 4 auto; }
+
+/*--------Responsive Table Object----------*/
+
+:root {
+  --Table-border: 1px solid #145878;
+  --Table-label-color: var(--litegray);
+  --Table-label-size: .625rem;
+  --Table-label-width: 7rem;
+  --Table-label-alignment: left;
+}
+
+.RDTable { width: 100%; }
+.RDTable__heading { display: none; }
+.RDTable__content { display: block; }
+
+.RDTable__content::before {
+  content: attr(data-heading);
+  display: inline-block;
+  width: var(--Table-label-width);
+  margin-right: 1rem;
+  color: var(--Table-label-color);
+  font-size: var(--Table-label-size);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  text-align: var(--Table-label-alignment);
+}
+
+.RDTable__row:not(:last-of-type) {
+  border-bottom: var(--Table-border);
+}
+
+@media only screen and (min-width: 48rem) {
+  .RDTable__content,
+  .RDTable__heading { display: table-cell; }
+
+  .RDTable__content::before { display: none; }
+}

--- a/pluton.css/package.json
+++ b/pluton.css/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "pluton.css",
+  "private": true,
+  "version": "1.1.3",
+  "description": "The historical lightweight subset of Obsidian.css",
+  "main": "index.css",
+  "browser": "dist/pluton.css",
+  "files": [
+    "*.css",
+    "dist/*"
+  ],
+  "scripts": {
+    "clean": "del ./dist",
+    "dev": "postcss index.css -o dist/pluton.css --watch",
+    "build": "npm run build:dev && npm run build:prod",
+    "build:dev": "postcss index.css -o dist/pluton.css",
+    "build:prod": "postcss dist/pluton.css --env production -o dist/pluton.min.css --no-map",
+    "check": "npm run lint",
+    "lint": "stylelint './*.css'"
+  },
+  "keywords": [
+    "css",
+    "modular css",
+    "postcss"
+  ],
+  "author": "charles peters <charlespeters42@gmail.com>",
+  "license": "MIT",
+  "repository": "charliewilco/layr",
+  "bugs": {
+    "url": "https://github.com/charliewilco/layr/issues"
+  },
+  "homepage": "https://github.com/charliewilco/layr/tree/main/pluton.css",
+  "devDependencies": {
+    "autoprefixer": "^10.5.4",
+    "cssnano": "^8.0.2",
+    "del-cli": "^7.0.0",
+    "postcss": "^8.5.23",
+    "postcss-cli": "^11.0.1",
+    "postcss-import": "^16.1.1",
+    "stylelint": "^17.14.1"
+  },
+  "browserslist": [
+    "last 1 versions"
+  ],
+  "stylelint": {
+    "rules": {
+      "block-no-empty": true,
+      "color-no-invalid-hex": true,
+      "no-invalid-double-slash-comments": true
+    }
+  },
+  "cssnano": {
+    "preset": [
+      "default",
+      {
+        "discardComments": {
+          "removeAllButFirst": true
+        }
+      }
+    ]
+  }
+}

--- a/pluton.css/postcss.config.cjs
+++ b/pluton.css/postcss.config.cjs
@@ -1,0 +1,31 @@
+const autoprefixer = require("autoprefixer");
+const cssnano = require("cssnano");
+const postcssImport = require("postcss-import");
+
+module.exports = function postcssConfig(ctx) {
+  return {
+    map: false,
+    plugins:
+      ctx.env === "production"
+        ? [
+            cssnano({
+              preset: [
+                "default",
+                {
+                  discardComments: {
+                    removeAllButFirst: true,
+                  },
+                },
+              ],
+            }),
+          ]
+        : [
+            postcssImport({
+              skipDuplicates: true,
+            }),
+            autoprefixer({
+              remove: true,
+            }),
+          ],
+  };
+};

--- a/pluton.css/settings.css
+++ b/pluton.css/settings.css
@@ -1,0 +1,131 @@
+/*
+  SETTINGS - Project Wide Variables and Default Values
+
+  Colors............All Colors and Color Deviations.
+  Defaults..........Project Wide Variables, Theme & Custom Selectors.
+  Media Queries.....Custom Media Queries Declarations.
+*/
+
+/*----------Obsidian Default Colors----------*/
+
+:root {
+  /* Red */
+  --red: #D04D36;
+  --red-light: #F5DAD6;
+  --red-medium: #D04D36;
+  --red-dark: #8B0302;
+
+  /* Blue */
+  --blue: #147AAB;
+  --blue-light: #CFE4ED;
+  --blue-medium: #147AAB;
+  --blue-dark: #004470;
+
+  /* Bluegreen */
+  --bluegreen: #1D889D;
+  --bluegreen-light: #CDE4E9;
+  --bluegreen-medium: #1D889D;
+  --bluegreen-dark: #005064;
+
+  /* Yellow */
+  --yellow: #FFBA00;
+  --yellow-light: #FFDD83;
+  --yellow-medium: #FFBA00;
+  --yellow-dark: #B97F00;
+
+  /* Yellow Green */
+  --ygreen: #CEE89C;
+  --ygreen-light: #D1E9A3;
+  --ygreen-medium: #CEE89C;
+  --ygreen-dark: #90AA62;
+
+  /* Green */
+  --green: #6CC034;
+  --green-light: #CCE9E9;
+  --green-medium: #6CC034;
+  --green-dark: #278300;
+
+  /* Orange */
+  --orange: #E36511;
+  --orange-light: #F8DBC7;
+  --orange-medium: #E36511;
+  --orange-dark: #9C2900;
+
+  /* Purple */
+  --purple: #834F91;
+  --purple-light: #E7DDEA;
+  --purple-medium: #834F91;
+  --purple-dark: #4A1958;
+
+  /* Indigo */
+  --indigo: #675996;
+  --indigo-light: #E1DFEB;
+  --indigo-medium: #675997;
+  --indigo-dark: #2F265D;
+
+  /* Fuchsia */
+  --fuchsia: #FA5E5B;
+  --fuchsia-light: #FDD7D7;
+  --fuchsia-medium: #FA5E5B;
+  --fuchsia-dark: #B31528;
+
+  /* Grays */
+  --offwhite: #FDFDFD;
+  --black: #202020;
+  --palegray: #F7F7F7;
+  --gray: #CCC;
+  --text: #484848;
+  --litegray: #BCBCBC;
+}
+
+/*----------Obsidian Default Settings----------*/
+
+/*
+  NOTE: All defaults and computations
+*/
+
+/*----------Obsidian Default Theme----------*/
+
+:root {
+  /* Colors */
+  --color-1: var(--blue);
+  --color-2: var(--red);
+  --color-3: var(--yellow);
+  --color-4: var(--bluegreen);
+  --color-5: var(--litegray);
+
+  /* Font Choices */
+  --headlines: var(--ff-sans-serif);
+  --default: var(--ff-sans-serif);
+  --body-text: var(--ff-serif);
+}
+
+:root {
+  /* Spacing & Container */
+
+  --base-spacing: 1rem;
+  --base-flex: 18rem;
+  --base-container: 75rem;
+  --base-border: 1px;
+
+  /* Duration */
+
+  --base-dur: 375ms;
+  --base-timing-function: linear;
+
+  /* Shadows */
+
+  --shadow-1: 0 0 4px rgba(0, 0, 0, .035), 0 4px 8px rgba(0, 0, 0, .07);
+  --shadow-2: 0 0 4px rgba(0, 0, 0, .07), 0 4px 8px rgba(0, 0, 0, .14);
+  --shadow-3: 0 0 8px rgba(0, 0, 0, .18), 0 8px 16px rgba(0, 0, 0, .36);
+
+  /* Typography */
+
+  --ff-init-size: 100%;
+  --ff-sans-serif: -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', 'SF UI Text', 'Segoe UI', 'Fira Sans', 'Roboto', 'Noto Sans', 'Droid Sans', 'Helvetica Neue', 'Lucida Grande', sans-serif;
+  --ff-serif: 'Athelas', 'Charter', 'Hoefler Text', 'Baskerville', 'Droid Serif', 'Georgia', 'Times', serif;
+  --ff-mono: 'SF Mono', 'Source Code Pro', 'Menlo', monospace;
+  --ff-default: system, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', 'SF UI Text', 'Segoe UI', 'Roboto', 'Noto Sans', 'Helvetica Neue', 'Lucida Grande', sans-serif;
+  --ff-w: 300;
+  --lh: 1.6;
+}

--- a/pluton.css/utilities.css
+++ b/pluton.css/utilities.css
@@ -1,0 +1,1397 @@
+/*
+  UTILITIES - Helper Classes to Modify Components
+
+  Surfaces.........Color, Hover, Focus, Background and Border Colors & Shadows.
+  Fit..............Object Fit Utilties.
+  Positioning......Overflow X Y All, Positions, z-index utils.
+  Spacing..........Responsive Spacing - Margin, Padding.
+  Typography.......Alignment, Font Weights, Letter Spacing, Rendering, Columns, Text Transform.
+*/
+
+/*
+  Surfaces Utilities
+
+  Background........Background Values (Color, None)
+  Colors............Color and Fill Values
+*/
+
+/*----------Background Value Utilities----------*/
+
+.u-bg--none      { background: none; }
+.u-bg--cover     { background-position: cover; }
+.u-bg--offwhite  { background-color: var(--offwhite); }
+.u-bg--black     { background-color: var(--black); }
+.u-bg--red       { background-color: var(--red); }
+.u-bg--blue      { background-color: var(--blue); }
+.u-bg--bluegreen { background-color: var(--bluegreen); }
+.u-bg--yellow    { background-color: var(--yellow); }
+.u-bg--ygreen    { background-color: var(--ygreen); }
+.u-bg--green     { background-color: var(--green); }
+.u-bg--orange    { background-color: var(--orange); }
+.u-bg--purple    { background-color: var(--purple); }
+.u-bg--indigo    { background-color: var(--indigo); }
+.u-bg--fuchsia   { background-color: var(--fuchsia); }
+.u-bg--gray      { background-color: var(--gray); }
+.u-bg--palegray  { background-color: var(--palegray); }
+.u-bg--text      { background-color: var(--text); }
+.u-bg--ltgray    { background-color: var(--litegray); }
+
+/*----------Color Value Utilities----------*/
+
+.u-offwhite  { color: var(--offwhite); }
+.u-black     { color: var(--black); }
+.u-red       { color: var(--red); }
+.u-blue      { color: var(--blue); }
+.u-bluegreen { color: var(--bluegreen); }
+.u-yellow    { color: var(--yellow); }
+.u-ygreen    { color: var(--ygreen); }
+.u-green     { color: var(--green); }
+.u-orange    { color: var(--orange); }
+.u-purple    { color: var(--purple); }
+.u-indigo    { color: var(--indigo); }
+.u-fuchsia   { color: var(--fuchsia); }
+.u-gray      { color: var(--gray); }
+.u-palegray  { color: var(--palegray); }
+.u-text      { color: var(--text); }
+.u-ltgray    { color: var(--litegray); }
+.u-fcc { fill: currentColor; }
+
+
+/*
+  Layout Utilities
+
+  Display..........Breakpoint Specific Display Properties.
+  Floats...........Clearfix, Breakpoint Floats.
+  Width............max-width, width
+*/
+
+/*----------Display Utilities----------*/
+
+.u-inbl   { display: inline-block; }
+.u-in     { display: inline; }
+.u-bl     { display: block; }
+.u-none   { display: none; }
+.u-inflex { display: inline-flex; }
+.u-table  { display: table-cell; }
+
+@media only screen and (min-width: 31.25rem) {
+  .u-inbl\@sm   { display: inline-block; }
+  .u-in\@sm     { display: inline; }
+  .u-bl\@sm     { display: block; }
+  .u-none\@sm   { display: none; }
+  .u-inflex\@sm { display: inline-flex; }
+  .u-table\@sm  { display: table-cell; }
+}
+
+@media only screen and (min-width: 48rem) {
+  .u-inbl\@md   { display: inline-block; }
+  .u-in\@md     { display: inline; }
+  .u-bl\@md     { display: block; }
+  .u-none\@md   { display: none; }
+  .u-inflex\@md { display: inline-flex; }
+  .u-table\@md  { display: table-cell; }
+}
+
+@media only screen and (min-width: 57.75rem) {
+  .u-inbl\@lg   { display: inline-block; }
+  .u-in\@lg     { display: inline; }
+  .u-bl\@lg     { display: block; }
+  .u-none\@lg   { display: none; }
+  .u-inflex\@lg { display: inline-flex; }
+  .u-table\@lg  { display: table-cell; }
+}
+
+/*----------Float Utilities----------*/
+
+.u-fl { float: left; }
+.u-fr { float: right; }
+.u-fn { float: none; }
+
+@media only screen and (min-width: 31.25rem) {
+  .u-fl\@sm  { float: left; }
+  .u-fr\@sm  { float: right; }
+  .u-fn\@sm  { float: none; }
+}
+
+@media only screen and (min-width: 48rem) {
+  .u-fl\@md  { float: left; }
+  .u-fr\@md  { float: right; }
+  .u-fn\@md  { float: none; }
+}
+
+@media only screen and (min-width: 57.75rem) {
+  .u-fl\@lg  { float: left; }
+  .u-fr\@lg  { float: right; }
+  .u-fn\@lg  { float: none; }
+}
+
+/* Clearfix */
+
+.u-cf:after {
+  content: '';
+  clear: both;
+  display: table;
+}
+
+.u-wd--100   { width: 100%; }
+.u-mxw--auto { max-width: auto; }
+.u-mxw--fit  { max-width: 100%; }
+
+/*
+  Positioning Utilities
+
+  Position.........Absolute, Static, Fixed, Relative
+*/
+
+
+/*----------Position Utilities----------*/
+
+.u-absolute { position: absolute; }
+.u-fixed    { position: fixed; }
+.u-static   { position: static; }
+.u-relative { position: relative; }
+
+.u-tblr {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+/*---------Spacing Utilities----------*/
+
+/*
+  NOTE: Adapted from Basscss from Brent Jackson
+  http://www.basscss.com/#basscss-margin
+  http://www.basscss.com/#basscss-padding
+*/
+
+/*---------Spacing Utilities: Margin----------*/
+
+/* Spacing Level 0 */
+
+.u-m0  { margin: 0; }
+.u-mt0 { margin-top: 0; }
+.u-mr0 { margin-right: 0; }
+.u-mb0 { margin-bottom: 0; }
+.u-ml0 { margin-left: 0; }
+
+.u-mx0 {
+  margin-right: 0;
+  margin-left: 0;
+}
+
+.u-my0 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* Spacing Level 1 */
+
+.u-m1  { margin: var(--spacing-1); }
+.u-mt1 { margin-top: var(--spacing-1); }
+.u-mr1 { margin-right: var(--spacing-1); }
+.u-mb1 { margin-bottom: var(--spacing-1); }
+.u-ml1 { margin-left: var(--spacing-1); }
+
+.u-mx1 {
+  margin-right: var(--spacing-1);
+  margin-left: var(--spacing-1);
+}
+
+.u-my1 {
+  margin-top: var(--spacing-1);
+  margin-bottom: var(--spacing-1);
+}
+
+/* Spacing Level 2 */
+
+.u-m2  { margin: var(--spacing-2); }
+.u-mt2 { margin-top: var(--spacing-2); }
+.u-mr2 { margin-right: var(--spacing-2); }
+.u-mb2 { margin-bottom: var(--spacing-2); }
+.u-ml2 { margin-left: var(--spacing-2); }
+
+.u-mx2 {
+  margin-right: var(--spacing-2);
+  margin-left: var(--spacing-2);
+}
+
+.u-my2 {
+  margin-top: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+/* Spacing Level 3 */
+
+.u-m3  {  margin: var(--spacing-3); }
+.u-mt3 {  margin-top: var(--spacing-3); }
+.u-mr3 {  margin-right: var(--spacing-3); }
+.u-mb3 {  margin-bottom: var(--spacing-3); }
+.u-ml3 {  margin-left: var(--spacing-3); }
+
+.u-mx3 {
+  margin-right: var(--spacing-3);
+  margin-left: var(--spacing-3);
+}
+
+.u-my3 {
+  margin-top: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+}
+
+/* Spacing Level 4 */
+
+.u-m4  { margin: var(--spacing-4); }
+.u-mt4 { margin-top: var(--spacing-4); }
+.u-mr4 { margin-right: var(--spacing-4); }
+.u-mb4 { margin-bottom: var(--spacing-4); }
+.u-ml4 { margin-left: var(--spacing-4); }
+
+.u-mx4 {
+  margin-right: var(--spacing-4);
+  margin-left: var(--spacing-4);
+}
+
+.u-my4 {
+  margin-top: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+}
+
+/* Spacing Level 5 */
+
+.u-m5  {  margin: var(--spacing-5); }
+.u-mt5 { margin-top: var(--spacing-5); }
+.u-mr5 {  margin-right: var(--spacing-5); }
+.u-mb5 {  margin-bottom: var(--spacing-5); }
+.u-ml5 {  margin-left: var(--spacing-5); }
+
+.u-mx5 {
+  margin-right: var(--spacing-5);
+  margin-left: var(--spacing-5);
+}
+
+.u-my5 {
+  margin-top: var(--spacing-5);
+  margin-bottom: var(--spacing-5);
+}
+
+/* Spacing Level 6 */
+
+.u-m6  { margin: var(--spacing-6); }
+.u-mt6 { margin-top: var(--spacing-6); }
+.u-mr6 { margin-right: var(--spacing-6); }
+.u-mb6 { margin-bottom: var(--spacing-6); }
+.u-ml6 { margin-left: var(--spacing-6); }
+
+.u-mx6 {
+  margin-right: var(--spacing-6);
+  margin-left: var(--spacing-6);
+}
+
+.u-my6 {
+  margin-top: var(--spacing-6);
+  margin-bottom: var(--spacing-6);
+}
+
+/* Spacing Auto */
+
+.u-mla { margin-left: auto; }
+
+.u-mra { margin-right: auto; }
+
+.u-mxa {
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.u-mya {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+@media only screen and (min-width: 31.25rem) {
+
+  /* Spacing Level 0 */
+
+  .u-m0\@sm  { margin: 0; }
+  .u-mt0\@sm { margin-top: 0; }
+  .u-mr0\@sm { margin-right: 0; }
+  .u-mb0\@sm { margin-bottom: 0; }
+  .u-ml0\@sm { margin-left: 0; }
+
+  .u-mx0\@sm {
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  .u-my0\@sm {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  /* Spacing Level 1 */
+
+  .u-m1\@sm  { margin: var(--spacing-1); }
+  .u-mt1\@sm { margin-top: var(--spacing-1); }
+  .u-mr1\@sm { margin-right: var(--spacing-1); }
+  .u-mb1\@sm { margin-bottom: var(--spacing-1); }
+  .u-ml1\@sm { margin-left: var(--spacing-1); }
+
+  .u-mx1\@sm {
+    margin-right: var(--spacing-1);
+    margin-left: var(--spacing-1);
+  }
+
+  .u-my1\@sm {
+    margin-top: var(--spacing-1);
+    margin-bottom: var(--spacing-1);
+  }
+
+  /* Spacing Level 2 */
+
+  .u-m2\@sm  { margin: var(--spacing-2); }
+  .u-mt2\@sm { margin-top: var(--spacing-2); }
+  .u-mr2\@sm { margin-right: var(--spacing-2); }
+  .u-mb2\@sm { margin-bottom: var(--spacing-2); }
+  .u-ml2\@sm { margin-left: var(--spacing-2); }
+
+  .u-mx2\@sm {
+    margin-right: var(--spacing-2);
+    margin-left: var(--spacing-2);
+  }
+
+  .u-my2\@sm {
+    margin-top: var(--spacing-2);
+    margin-bottom: var(--spacing-2);
+  }
+
+  /* Spacing Level 3 */
+
+  .u-m3\@sm  {  margin: var(--spacing-3); }
+  .u-mt3\@sm {  margin-top: var(--spacing-3); }
+  .u-mr3\@sm {  margin-right: var(--spacing-3); }
+  .u-mb3\@sm {  margin-bottom: var(--spacing-3); }
+  .u-ml3\@sm {  margin-left: var(--spacing-3); }
+
+  .u-mx3\@sm {
+    margin-right: var(--spacing-3);
+    margin-left: var(--spacing-3);
+  }
+
+  .u-my3\@sm {
+    margin-top: var(--spacing-3);
+    margin-bottom: var(--spacing-3);
+  }
+
+  /* Spacing Level 4 */
+
+  .u-m4\@sm  { margin: var(--spacing-4); }
+  .u-mt4\@sm { margin-top: var(--spacing-4); }
+  .u-mr4\@sm { margin-right: var(--spacing-4); }
+  .u-mb4\@sm { margin-bottom: var(--spacing-4); }
+  .u-ml4\@sm { margin-left: var(--spacing-4); }
+
+  .u-mx4\@sm {
+    margin-right: var(--spacing-4);
+    margin-left: var(--spacing-4);
+  }
+
+  .u-my4\@sm {
+    margin-top: var(--spacing-4);
+    margin-bottom: var(--spacing-4);
+  }
+
+  /* Spacing Level 4 */
+
+  .u-m5\@sm  { margin: var(--spacing-5); }
+  .u-mt5\@sm { margin-top: var(--spacing-5); }
+  .u-mr5\@sm { margin-right: var(--spacing-5); }
+  .u-mb5\@sm { margin-bottom: var(--spacing-5); }
+  .u-ml5\@sm { margin-left: var(--spacing-5); }
+
+  .u-mx5\@sm {
+    margin-right: var(--spacing-5);
+    margin-left: var(--spacing-5);
+  }
+
+  .u-my5\@sm {
+    margin-top: var(--spacing-5);
+    margin-bottom: var(--spacing-5);
+  }
+
+  /* Spacing Level 6 */
+
+  .u-m6\@sm  { margin: var(--spacing-6); }
+  .u-mt6\@sm { margin-top: var(--spacing-6); }
+  .u-mr6\@sm { margin-right: var(--spacing-6); }
+  .u-mb6\@sm { margin-bottom: var(--spacing-6); }
+  .u-ml6\@sm { margin-left: var(--spacing-6); }
+
+  .u-mx6\@sm {
+    margin-right: var(--spacing-6);
+    margin-left: var(--spacing-6);
+  }
+
+  .u-my6\@sm {
+    margin-top: var(--spacing-6);
+    margin-bottom: var(--spacing-6);
+  }
+
+  /* Spacing Auto */
+
+  .u-mla\@sm { margin-left: auto; }
+  .u-mra\@sm { margin-right: auto; }
+
+  .u-mxa\@sm {
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  .u-mya\@sm {
+    margin-top: auto;
+    margin-bottom: auto;
+  }
+}
+
+@media only screen and (min-width: 48rem) {
+
+  /* Spacing Level 0 */
+
+  .u-m0\@md  { margin: 0; }
+  .u-mt0\@md { margin-top: 0; }
+  .u-mr0\@md { margin-right: 0; }
+  .u-mb0\@md { margin-bottom: 0; }
+  .u-ml0\@md { margin-left: 0; }
+
+  .u-mx0\@md {
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  .u-my0\@md {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  /* Spacing Level 1 */
+
+  .u-m1\@md  {  margin: var(--spacing-1); }
+  .u-mt1\@md {  margin-top: var(--spacing-1); }
+  .u-mr1\@md {  margin-right: var(--spacing-1); }
+  .u-mb1\@md {  margin-bottom: var(--spacing-1); }
+  .u-ml1\@md {  margin-left: var(--spacing-1); }
+
+  .u-mx1\@md {
+
+    margin-right: var(--spacing-1);
+
+    margin-left: var(--spacing-1);
+  }
+
+  .u-my1\@md {
+
+    margin-top: var(--spacing-1);
+
+    margin-bottom: var(--spacing-1);
+  }
+
+  /* Spacing Level 2 */
+
+  .u-m2\@md  { margin: var(--spacing-2); }
+  .u-mt2\@md { margin-top: var(--spacing-2); }
+  .u-mr2\@md { margin-right: var(--spacing-2); }
+  .u-mb2\@md { margin-bottom: var(--spacing-2); }
+  .u-ml2\@md { margin-left: var(--spacing-2); }
+
+  .u-mx2\@md {
+    margin-right: var(--spacing-2);
+    margin-left: var(--spacing-2);
+  }
+
+  .u-my2\@md {
+    margin-top: var(--spacing-2);
+    margin-bottom: var(--spacing-2);
+  }
+
+  /* Spacing Level 3 */
+
+  .u-m3\@md  { margin: var(--spacing-3); }
+  .u-mt3\@md { margin-top: var(--spacing-3); }
+  .u-mr3\@md { margin-right: var(--spacing-3); }
+  .u-mb3\@md { margin-bottom: var(--spacing-3); }
+  .u-ml3\@md { margin-left: var(--spacing-3); }
+
+  .u-mx3\@md {
+    margin-right: var(--spacing-3);
+    margin-left: var(--spacing-3);
+  }
+
+  .u-my3\@md {
+    margin-top: var(--spacing-3);
+    margin-bottom: var(--spacing-3);
+  }
+
+  /* Spacing Level 4 */
+
+  .u-m4\@md  { margin: var(--spacing-4); }
+  .u-mt4\@md { margin-top: var(--spacing-4); }
+  .u-mr4\@md { margin-right: var(--spacing-4); }
+  .u-mb4\@md { margin-bottom: var(--spacing-4); }
+  .u-ml4\@md { margin-left: var(--spacing-4); }
+
+  .u-mx4\@md {
+    margin-right: var(--spacing-4);
+    margin-left: var(--spacing-4);
+  }
+
+  .u-my4\@md {
+    margin-top: var(--spacing-4);
+    margin-bottom: var(--spacing-4);
+  }
+
+  /* Spacing Level 5 */
+
+  .u-m5\@md  { margin: var(--spacing-5); }
+  .u-mt5\@md { margin-top: var(--spacing-5); }
+  .u-mr5\@md { margin-right: var(--spacing-5); }
+  .u-mb5\@md { margin-bottom: var(--spacing-5); }
+  .u-ml5\@md { margin-left: var(--spacing-5); }
+
+  .u-mx5\@md {
+    margin-right: var(--spacing-5);
+    margin-left: var(--spacing-5);
+  }
+
+  .u-my5\@md {
+    margin-top: var(--spacing-5);
+    margin-bottom: var(--spacing-5);
+  }
+
+  /* Spacing Level 6 */
+
+  .u-m6\@md  { margin: var(--spacing-6); }
+  .u-mt6\@md { margin-top: var(--spacing-6); }
+  .u-mr6\@md { margin-right: var(--spacing-6); }
+  .u-mb6\@md { margin-bottom: var(--spacing-6); }
+  .u-ml6\@md { margin-left: var(--spacing-6); }
+
+  .u-mx6\@md {
+    margin-right: var(--spacing-6);
+    margin-left: var(--spacing-6);
+  }
+
+  .u-my6\@md {
+    margin-top: var(--spacing-6);
+    margin-bottom: var(--spacing-6);
+  }
+
+  /* Spacing Auto */
+
+  .u-mla\@md { margin-left: auto; }
+  .u-mra\@md { margin-right: auto; }
+
+  .u-mxa\@md {
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  .u-mya\@md {
+    margin-top: auto;
+    margin-bottom: auto;
+  }
+}
+
+@media only screen and (min-width: 57.75rem) {
+
+  /* Spacing Level 0 */
+
+  .u-m0\@lg  { margin: 0; }
+  .u-mt0\@lg { margin-top: 0; }
+  .u-mr0\@lg { margin-right: 0; }
+  .u-mb0\@lg { margin-bottom: 0; }
+  .u-ml0\@lg { margin-left: 0; }
+
+  .u-mx0\@lg {
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  .u-my0\@lg {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  /* Spacing Level 1 */
+
+  .u-m1\@lg  {  margin: var(--spacing-1); }
+  .u-mt1\@lg {  margin-top: var(--spacing-1); }
+  .u-mr1\@lg {  margin-right: var(--spacing-1); }
+  .u-mb1\@lg {  margin-bottom: var(--spacing-1); }
+  .u-ml1\@lg {  margin-left: var(--spacing-1); }
+
+  .u-mx1\@lg {
+    margin-right: var(--spacing-1);
+    margin-left: var(--spacing-1);
+  }
+
+  .u-my1\@lg {
+    margin-top: var(--spacing-1);
+    margin-bottom: var(--spacing-1);
+  }
+
+  /* Spacing Level 2 */
+
+  .u-m2\@lg  { margin: var(--spacing-2); }
+  .u-mt2\@lg { margin-top: var(--spacing-2); }
+  .u-mr2\@lg { margin-right: var(--spacing-2); }
+  .u-mb2\@lg { margin-bottom: var(--spacing-2); }
+  .u-ml2\@lg { margin-left: var(--spacing-2); }
+
+  .u-mx2\@lg {
+    margin-right: var(--spacing-2);
+    margin-left: var(--spacing-2);
+  }
+
+  .u-my2\@lg {
+    margin-top: var(--spacing-2);
+    margin-bottom: var(--spacing-2);
+  }
+
+  /* Spacing Level 3 */
+
+  .u-m3\@lg  {  margin: var(--spacing-3); }
+  .u-mt3\@lg {  margin-top: var(--spacing-3); }
+  .u-mr3\@lg {  margin-right: var(--spacing-3); }
+  .u-mb3\@lg {  margin-bottom: var(--spacing-3); }
+  .u-ml3\@lg {  margin-left: var(--spacing-3); }
+
+  .u-mx3\@lg {
+    margin-right: var(--spacing-3);
+    margin-left: var(--spacing-3);
+  }
+
+  .u-my3\@lg {
+    margin-top: var(--spacing-3);
+    margin-bottom: var(--spacing-3);
+  }
+
+  /* Spacing Level 4 */
+
+  .u-m4\@lg  {  margin: var(--spacing-4); }
+  .u-mt4\@lg {  margin-top: var(--spacing-4); }
+  .u-mr4\@lg {  margin-right: var(--spacing-4); }
+  .u-mb4\@lg {  margin-bottom: var(--spacing-4); }
+  .u-ml4\@lg {  margin-left: var(--spacing-4); }
+
+  .u-mx4\@lg {
+    margin-right: var(--spacing-4);
+    margin-left: var(--spacing-4);
+  }
+
+  .u-my4\@lg {
+    margin-top: var(--spacing-4);
+    margin-bottom: var(--spacing-4);
+  }
+
+  /* Spacing Level 5 */
+
+  .u-m5\@lg  {  margin: var(--spacing-5); }
+  .u-mt5\@lg { margin-top: var(--spacing-5); }
+  .u-mr5\@lg {  margin-right: var(--spacing-5); }
+  .u-mb5\@lg {  margin-bottom: var(--spacing-5); }
+  .u-ml5\@lg {  margin-left: var(--spacing-5); }
+
+  .u-mx5\@lg {
+    margin-right: var(--spacing-5);
+    margin-left: var(--spacing-5);
+  }
+
+  .u-my5\@lg {
+    margin-top: var(--spacing-5);
+    margin-bottom: var(--spacing-5);
+  }
+
+  /* Spacing Level 6 */
+
+  .u-m6\@lg  { margin: var(--spacing-6); }
+  .u-mt6\@lg { margin-top: var(--spacing-6); }
+  .u-mr6\@lg { margin-right: var(--spacing-6); }
+  .u-mb6\@lg { margin-bottom: var(--spacing-6); }
+  .u-ml6\@lg { margin-left: var(--spacing-6); }
+
+  .u-mx6\@lg {
+    margin-right: var(--spacing-6);
+    margin-left: var(--spacing-6);
+  }
+
+  .u-my6\@lg {
+    margin-top: var(--spacing-6);
+    margin-bottom: var(--spacing-6);
+  }
+
+  /* Spacing Auto */
+
+  .u-mla\@lg { margin-left: auto; }
+  .u-mra\@lg { margin-right: auto; }
+
+  .u-mxa\@lg {
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  .u-mya\@lg {
+    margin-top: auto;
+    margin-bottom: auto;
+  }
+}
+
+/*---------Spacing Utilities: Padding----------*/
+
+/* Spacing Level 0 */
+
+.u-p0  { padding: 0; }
+.u-pt0 { padding-top: 0; }
+.u-pr0 { padding-right: 0; }
+.u-pb0 { padding-bottom: 0; }
+.u-pl0 { padding-left: 0; }
+
+.u-px0 {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.u-py0 {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+/* Spacing Level 1 */
+
+.u-p1  { padding: var(--spacing-1); }
+.u-pt1 { padding-top: var(--spacing-1); }
+.u-pr1 { padding-right: var(--spacing-1); }
+.u-pb1 { padding-bottom: var(--spacing-1); }
+.u-pl1 { padding-left: var(--spacing-1); }
+
+.u-px1 {
+  padding-right: var(--spacing-1);
+  padding-left: var(--spacing-1);
+}
+
+.u-py1 {
+  padding-top: var(--spacing-1);
+  padding-bottom: var(--spacing-1);
+}
+
+/* Spacing Level 2 */
+
+.u-p2  { padding: var(--spacing-2); }
+.u-pt2 { padding-top: var(--spacing-2); }
+.u-pr2 { padding-right: var(--spacing-2); }
+.u-pb2 { padding-bottom: var(--spacing-2); }
+.u-pl2 { padding-left: var(--spacing-2); }
+
+.u-px2 {
+  padding-right: var(--spacing-2);
+  padding-left: var(--spacing-2);
+}
+
+.u-py2 {
+  padding-top: var(--spacing-2);
+  padding-bottom: var(--spacing-2);
+}
+
+/* Spacing Level 3 */
+
+.u-p3  { padding: var(--spacing-3); }
+.u-pt3 { padding-top: var(--spacing-3); }
+.u-pr3 { padding-right: var(--spacing-3); }
+.u-pb3 { padding-bottom: var(--spacing-3); }
+.u-pl3 { padding-left: var(--spacing-3); }
+
+.u-px3 {
+  padding-right: var(--spacing-3);
+  padding-left: var(--spacing-3);
+}
+
+.u-py3 {
+  padding-top: var(--spacing-3);
+  padding-bottom: var(--spacing-3);
+}
+
+/* Spacing Level 4 */
+
+.u-p4  { padding: var(--spacing-4); }
+.u-pt4 { padding-top: var(--spacing-4); }
+.u-pr4 { padding-right: var(--spacing-4); }
+.u-pb4 { padding-bottom: var(--spacing-4); }
+.u-pl4 { padding-left: var(--spacing-4); }
+
+.u-px4 {
+  padding-right: var(--spacing-4);
+  padding-left: var(--spacing-4);
+}
+
+.u-py4 {
+  padding-top: var(--spacing-4);
+  padding-bottom: var(--spacing-4);
+}
+
+/* Spacing Level 5 */
+
+.u-p5  { padding: var(--spacing-5); }
+.u-pt5 { padding-top: var(--spacing-5); }
+.u-pr5 { padding-right: var(--spacing-5); }
+.u-pb5 { padding-bottom: var(--spacing-5); }
+.u-pl5 { padding-left: var(--spacing-5); }
+
+.u-px5 {
+  padding-right: var(--spacing-5);
+  padding-left: var(--spacing-5);
+}
+
+.u-py5 {
+  padding-top: var(--spacing-5);
+  padding-bottom: var(--spacing-5);
+}
+
+/* Spacing Level 6 */
+
+.u-p6  { padding: var(--spacing-6); }
+.u-pt6 { padding-top: var(--spacing-6); }
+.u-pr6 { padding-right: var(--spacing-6); }
+.u-pb6 { padding-bottom: var(--spacing-6); }
+.u-pl6 { padding-left: var(--spacing-6); }
+
+.u-px6 {
+  padding-right: var(--spacing-6);
+  padding-left: var(--spacing-6);
+}
+
+.u-py6 {
+  padding-top: var(--spacing-6);
+  padding-bottom: var(--spacing-6);
+}
+
+/* Spacing Auto */
+
+.u-px-auto {
+  padding-right: auto;
+  padding-left: auto;
+}
+
+.u-py-auto {
+  padding-top: auto;
+  padding-bottom: auto;
+}
+
+@media only screen and (min-width: 31.25rem) {
+
+  /* Spacing Level 0 */
+
+  .u-p0\@sm  { padding: 0; }
+  .u-pt0\@sm { padding-top: 0; }
+  .u-pr0\@sm { padding-right: 0; }
+  .u-pb0\@sm { padding-bottom: 0; }
+  .u-pl0\@sm { padding-left: 0; }
+
+  .u-px0\@sm {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .u-py0\@sm {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  /* Spacing Level 1 */
+
+  .u-p1\@sm  { padding: var(--spacing-1); }
+  .u-pt1\@sm { padding-top: var(--spacing-1); }
+  .u-pr1\@sm { padding-right: var(--spacing-1); }
+  .u-pb1\@sm { padding-bottom: var(--spacing-1); }
+  .u-pl1\@sm { padding-left: var(--spacing-1); }
+
+  .u-px1\@sm {
+    padding-right: var(--spacing-1);
+    padding-left: var(--spacing-1);
+  }
+
+  .u-py1\@sm {
+    padding-top: var(--spacing-1);
+    padding-bottom: var(--spacing-1);
+  }
+
+  /* Spacing Level 2 */
+
+  .u-p2\@sm  { padding: var(--spacing-2); }
+  .u-pt2\@sm { padding-top: var(--spacing-2); }
+  .u-pr2\@sm { padding-right: var(--spacing-2); }
+  .u-pb2\@sm { padding-bottom: var(--spacing-2); }
+  .u-pl2\@sm { padding-left: var(--spacing-2); }
+
+  .u-px2\@sm {
+    padding-right: var(--spacing-2);
+    padding-left: var(--spacing-2);
+  }
+
+  .u-py2\@sm {
+    padding-top: var(--spacing-2);
+    padding-bottom: var(--spacing-2);
+  }
+
+  /* Spacing Level 3 */
+
+  .u-p3\@sm  { padding: var(--spacing-3); }
+  .u-pt3\@sm { padding-top: var(--spacing-3); }
+  .u-pr3\@sm { padding-right: var(--spacing-3); }
+  .u-pb3\@sm { padding-bottom: var(--spacing-3); }
+  .u-pl3\@sm { padding-left: var(--spacing-3); }
+
+  .u-px3\@sm {
+    padding-right: var(--spacing-3);
+    padding-left: var(--spacing-3);
+  }
+
+  .u-py3\@sm {
+    padding-top: var(--spacing-3);
+    padding-bottom: var(--spacing-3);
+  }
+
+  /* Spacing Level 4 */
+
+  .u-p4\@sm  { padding: var(--spacing-4); }
+  .u-pt4\@sm { padding-top: var(--spacing-4); }
+  .u-pr4\@sm { padding-right: var(--spacing-4); }
+  .u-pb4\@sm { padding-bottom: var(--spacing-4); }
+  .u-pl4\@sm { padding-left: var(--spacing-4); }
+
+  .u-px4\@sm {
+    padding-right: var(--spacing-4);
+    padding-left: var(--spacing-4);
+  }
+
+  .u-py4\@sm {
+    padding-top: var(--spacing-4);
+    padding-bottom: var(--spacing-4);
+  }
+
+  /* Spacing Level 4 */
+
+  .u-p5\@sm  { padding: var(--spacing-5); }
+  .u-pt5\@sm { padding-top: var(--spacing-5); }
+  .u-pr5\@sm { padding-right: var(--spacing-5); }
+  .u-pb5\@sm { padding-bottom: var(--spacing-5); }
+  .u-pl5\@sm { padding-left: var(--spacing-5); }
+
+  .u-px5\@sm {
+    padding-right: var(--spacing-5);
+    padding-left: var(--spacing-5);
+  }
+
+  .u-py5\@sm {
+    padding-top: var(--spacing-5);
+    padding-bottom: var(--spacing-5);
+  }
+
+  /* Spacing Level 6 */
+
+  .u-p6\@sm  { padding: var(--spacing-6); }
+  .u-pt6\@sm { padding-top: var(--spacing-6); }
+  .u-pr6\@sm { padding-right: var(--spacing-6); }
+  .u-pb6\@sm { padding-bottom: var(--spacing-6); }
+  .u-pl6\@sm { padding-left: var(--spacing-6); }
+
+  .u-px6\@sm {
+    padding-right: var(--spacing-6);
+    padding-left: var(--spacing-6);
+  }
+
+  .u-py6\@sm {
+    padding-top: var(--spacing-6);
+    padding-bottom: var(--spacing-6);
+  }
+
+  /* Spacing Auto */
+
+  .u-px-auto\@sm {
+    padding-right: auto;
+    padding-left: auto;
+  }
+
+  .u-py-auto\@sm {
+    padding-top: auto;
+    padding-bottom: auto;
+  }
+}
+
+@media only screen and (min-width: 48rem) {
+
+  /* Spacing Level 0 */
+
+  .u-p0\@md  { padding: 0; }
+  .u-pt0\@md { padding-top: 0; }
+  .u-pr0\@md { padding-right: 0; }
+  .u-pb0\@md { padding-bottom: 0; }
+  .u-pl0\@md { padding-left: 0; }
+
+  .u-px0\@md {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .u-py0\@md {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  /* Spacing Level 1 */
+
+  .u-p1\@md  { padding: var(--spacing-1); }
+  .u-pt1\@md { padding-top: var(--spacing-1); }
+  .u-pr1\@md { padding-right: var(--spacing-1); }
+  .u-pb1\@md { padding-bottom: var(--spacing-1); }
+  .u-pl1\@md { padding-left: var(--spacing-1); }
+
+  .u-px1\@md {
+    padding-right: var(--spacing-1);
+    padding-left: var(--spacing-1);
+  }
+
+  .u-py1\@md {
+    padding-top: var(--spacing-1);
+    padding-bottom: var(--spacing-1);
+  }
+
+  /* Spacing Level 2 */
+
+  .u-p2\@md  { padding: var(--spacing-2); }
+  .u-pt2\@md { padding-top: var(--spacing-2); }
+  .u-pr2\@md { padding-right: var(--spacing-2); }
+  .u-pb2\@md { padding-bottom: var(--spacing-2); }
+  .u-pl2\@md { padding-left: var(--spacing-2); }
+
+  .u-px2\@md {
+    padding-right: var(--spacing-2);
+    padding-left: var(--spacing-2);
+  }
+
+  .u-py2\@md {
+    padding-top: var(--spacing-2);
+    padding-bottom: var(--spacing-2);
+  }
+
+  /* Spacing Level 3 */
+
+  .u-p3\@md  { padding: var(--spacing-3); }
+  .u-pt3\@md { padding-top: var(--spacing-3); }
+  .u-pr3\@md { padding-right: var(--spacing-3); }
+  .u-pb3\@md { padding-bottom: var(--spacing-3); }
+  .u-pl3\@md { padding-left: var(--spacing-3); }
+
+  .u-px3\@md {
+    padding-right: var(--spacing-3);
+    padding-left: var(--spacing-3);
+  }
+
+  .u-py3\@md {
+    padding-top: var(--spacing-3);
+    padding-bottom: var(--spacing-3);
+  }
+
+  /* Spacing Level 4 */
+
+  .u-p4\@md  { padding: var(--spacing-4); }
+  .u-pt4\@md { padding-top: var(--spacing-4); }
+  .u-pr4\@md { padding-right: var(--spacing-4); }
+  .u-pb4\@md { padding-bottom: var(--spacing-4); }
+  .u-pl4\@md { padding-left: var(--spacing-4); }
+
+  .u-px4\@md {
+    padding-right: var(--spacing-4);
+    padding-left: var(--spacing-4);
+  }
+
+  .u-py4\@md {
+    padding-top: var(--spacing-4);
+    padding-bottom: var(--spacing-4);
+  }
+
+  /* Spacing Level 5 */
+
+  .u-p5\@md  { padding: var(--spacing-5); }
+  .u-pt5\@md { padding-top: var(--spacing-5); }
+  .u-pr5\@md { padding-right: var(--spacing-5); }
+  .u-pb5\@md { padding-bottom: var(--spacing-5); }
+  .u-pl5\@md { padding-left: var(--spacing-5); }
+
+  .u-px5\@md {
+    padding-right: var(--spacing-5);
+    padding-left: var(--spacing-5);
+  }
+
+  .u-py5\@md {
+    padding-top: var(--spacing-5);
+    padding-bottom: var(--spacing-5);
+  }
+
+  /* Spacing Level 6 */
+
+  .u-p6\@md  { padding: var(--spacing-6); }
+  .u-pt6\@md { padding-top: var(--spacing-6); }
+  .u-pr6\@md { padding-right: var(--spacing-6); }
+  .u-pb6\@md { padding-bottom: var(--spacing-6); }
+  .u-pl6\@md { padding-left: var(--spacing-6); }
+
+  .u-px6\@md {
+    padding-right: var(--spacing-6);
+    padding-left: var(--spacing-6);
+  }
+
+  .u-py6\@md {
+    padding-top: var(--spacing-6);
+    padding-bottom: var(--spacing-6);
+  }
+
+  /* Spacing Auto */
+
+  .u-px-auto\@md {
+    padding-right: auto;
+    padding-left: auto;
+  }
+
+  .u-py-auto\@md {
+    padding-top: auto;
+    padding-bottom: auto;
+  }
+}
+
+@media only screen and (min-width: 57.75rem) {
+
+  /* Spacing Level 0 */
+
+  .u-p0\@lg  { padding: 0; }
+  .u-pt0\@lg { padding-top: 0; }
+  .u-pr0\@lg { padding-right: 0; }
+  .u-pb0\@lg { padding-bottom: 0; }
+  .u-pl0\@lg { padding-left: 0; }
+
+  .u-px0\@lg {
+    padding-right: 0;
+    padding-left: 0;
+  }
+
+  .u-py0\@lg {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  /* Spacing Level 1 */
+
+  .u-p1\@lg  { padding: var(--spacing-1); }
+  .u-pt1\@lg { padding-top: var(--spacing-1); }
+  .u-pr1\@lg { padding-right: var(--spacing-1); }
+  .u-pb1\@lg { padding-bottom: var(--spacing-1); }
+  .u-pl1\@lg { padding-left: var(--spacing-1); }
+
+  .u-px1\@lg {
+    padding-right: var(--spacing-1);
+    padding-left: var(--spacing-1);
+  }
+
+  .u-py1\@lg {
+    padding-top: var(--spacing-1);
+    padding-bottom: var(--spacing-1);
+  }
+
+  /* Spacing Level 2 */
+
+  .u-p2\@lg  { padding: var(--spacing-2); }
+  .u-pt2\@lg { padding-top: var(--spacing-2); }
+  .u-pr2\@lg { padding-right: var(--spacing-2); }
+  .u-pb2\@lg { padding-bottom: var(--spacing-2); }
+  .u-pl2\@lg { padding-left: var(--spacing-2); }
+
+  .u-px2\@lg {
+    padding-right: var(--spacing-2);
+    padding-left: var(--spacing-2);
+  }
+
+  .u-py2\@lg {
+    padding-top: var(--spacing-2);
+    padding-bottom: var(--spacing-2);
+  }
+
+  /* Spacing Level 3 */
+
+  .u-p3\@lg  { padding: var(--spacing-3); }
+  .u-pt3\@lg { padding-top: var(--spacing-3); }
+  .u-pr3\@lg { padding-right: var(--spacing-3); }
+  .u-pb3\@lg { padding-bottom: var(--spacing-3); }
+  .u-pl3\@lg { padding-left: var(--spacing-3); }
+
+  .u-px3\@lg {
+    padding-right: var(--spacing-3);
+    padding-left: var(--spacing-3);
+  }
+
+  .u-py3\@lg {
+    padding-top: var(--spacing-3);
+    padding-bottom: var(--spacing-3);
+  }
+
+  .u-p4\@lg  { padding: var(--spacing-4); }
+  .u-pt4\@lg { padding-top: var(--spacing-4); }
+  .u-pr4\@lg { padding-right: var(--spacing-4); }
+  .u-pb4\@lg { padding-bottom: var(--spacing-4); }
+  .u-pl4\@lg { padding-left: var(--spacing-4); }
+
+  .u-px4\@lg {
+    padding-right: var(--spacing-4);
+    padding-left: var(--spacing-4);
+  }
+
+  .u-py4\@lg {
+    padding-top: var(--spacing-4);
+    padding-bottom: var(--spacing-4);
+  }
+
+  /* Spacing Level 5 */
+
+  .u-p5\@lg  { padding: var(--spacing-5); }
+  .u-pt5\@lg { padding-top: var(--spacing-5); }
+  .u-pr5\@lg { padding-right: var(--spacing-5); }
+  .u-pb5\@lg { padding-bottom: var(--spacing-5); }
+  .u-pl5\@lg { padding-left: var(--spacing-5); }
+
+  .u-px5\@lg {
+    padding-right: var(--spacing-5);
+    padding-left: var(--spacing-5);
+  }
+
+  .u-py5\@lg {
+    padding-top: var(--spacing-5);
+    padding-bottom: var(--spacing-5);
+  }
+
+  /* Spacing Level 6 */
+
+  .u-p6\@lg  { padding: var(--spacing-6); }
+  .u-pt6\@lg { padding-top: var(--spacing-6); }
+  .u-pr6\@lg { padding-right: var(--spacing-6); }
+  .u-pb6\@lg { padding-bottom: var(--spacing-6); }
+  .u-pl6\@lg { padding-left: var(--spacing-6); }
+
+  .u-px6\@lg {
+    padding-right: var(--spacing-6);
+    padding-left: var(--spacing-6);
+  }
+
+  .u-py6\@lg {
+    padding-top: var(--spacing-6);
+    padding-bottom: var(--spacing-6);
+  }
+
+  /* Spacing Auto */
+
+  .u-px-auto\@lg {
+    padding-right: auto;
+    padding-left: auto;
+  }
+
+  .u-py-auto\@lg {
+    padding-top: auto;
+    padding-bottom: auto;
+  }
+}
+
+:root {
+  --spacing-1: calc(var(--base-spacing) / 4);
+  --spacing-2: calc(var(--base-spacing) / 2);
+  --spacing-3: calc(var(--base-spacing));
+  --spacing-4: calc(var(--base-spacing) * 2);
+  --spacing-5: calc(var(--base-spacing) * 2.4);
+  --spacing-6: calc(var(--base-spacing) * 4);
+}
+
+/*
+  Typographic Utilities
+
+  Align................Breakpoint Specific Text Align.
+  Type Assorted........Font Weights, Letter Spacing, Rendering, Text Transform
+*/
+
+/*----------Text Align Utilities----------*/
+
+.u-left    { text-align: left; }
+.u-right   { text-align: right; }
+.u-center  { text-align: center; }
+.u-justify { text-align: justify; }
+
+@media only screen and (min-width: 31.25rem) {
+  .u-left\@sm    { text-align: left; }
+  .u-right\@sm   { text-align: right; }
+  .u-center\@sm  { text-align: center; }
+  .u-justify\@sm { text-align: justify; }
+}
+
+@media only screen and (min-width: 48rem) {
+  .u-left\@md    { text-align: left; }
+  .u-right\@md   { text-align: right; }
+  .u-center\@md  { text-align: center; }
+  .u-justify\@md { text-align: justify; }
+}
+
+@media only screen and (min-width: 57.75rem) {
+  .u-left\@lg    { text-align: left; }
+  .u-right\@lg   { text-align: right; }
+  .u-center\@lg  { text-align: center; }
+  .u-justify\@lg { text-align: justify; }
+}
+
+
+/*----------Typographic Grab-Bag----------*/
+
+/* Font Rendering */
+
+.u-anti {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Family */
+
+.u-serif  { font-family: var(--ff-serif); }
+.u-sans   { font-family: var(--ff-sans-serif); }
+.u-mono   { font-family: var(--ff-mono); }
+.u-system { font-family: var(--ff-default); }
+
+
+/* Line Height */
+
+.u-lh-1    { line-height: 1; }
+.u-lh-auto { line-height: auto; }
+
+/* Case */
+
+.u-caps  { text-transform: uppercase; }
+.u-lower { text-transform: lowercase; }
+
+/* Weights */
+
+.u-w300 { font-weight: 300; }
+.u-w400 { font-weight: 400; }
+.u-w500 { font-weight: 500; }
+.u-w600 { font-weight: 600; }
+.u-w700 { font-weight: 700; }
+
+
+/* Tracking */
+
+.u-lt-1 { letter-spacing: 1px; }
+.u-lt-2 { letter-spacing: 2px; }
+.u-lt-3 { letter-spacing: 3px; }
+.u-lt-4 { letter-spacing: 4px; }
+.u-lt-5 { letter-spacing: 5px; }


### PR DESCRIPTION
## Summary

- import the six source stylesheets from standalone `pluton.css@1.1.3` at commit `1610037`
- add Pluton as a private npm/Turbo workspace using the monorepo's current PostCSS toolchain
- preserve the historical package entry points and document its relationship to Obsidian.css and Layr

## Why

Pluton was a lightweight offshoot of Obsidian.css and belongs with the renamed Layr continuation. The standalone repository's 2017 Yarn/PostCSS 6 setup no longer installs cleanly on the monorepo's Node 26 baseline, so this imports the source unchanged while replacing only its build plumbing.

## Impact

The historical CSS API remains intact and the package is explicitly private to prevent accidental republishing. Generated bundles use the current Autoprefixer/cssnano versions, so they are source-compatible rather than byte-identical to the 2017 npm artifacts.

## Validation

- `npm ci` with Node 26.3.0
- `npm run clean`
- `npm run build`
- `npm run check`
- `npm run lint`
- `npm run test`
- `npm audit --audit-level=moderate`
- GitHub Pages-mode documentation build and generated-path check
- Pluton package dry run and source comparison against standalone commit `1610037`
- Prettier check on the new package metadata, configuration, and README
- `git diff --check`