### PR TITLE
Fix documentation snippet spacing

### DIFF
--- a/documentation/global.css
+++ b/documentation/global.css
@@ -1,11 +1,20 @@
-code[class*='language-'],
-pre[class*='language-'] {
-  font-family: 'SF Mono', 'Source Code Pro', 'Menlo', monospace !important;
+code[class*="language-"],
+pre[class*="language-"] {
+  font-family: "SF Mono", "Source Code Pro", "Menlo", monospace !important;
+}
+
+pre.astro-code,
+pre[class*="language-"],
+.Snippet__code {
+  margin-block: var(--base-spacing);
+  padding: var(--base-spacing);
 }
 
 .Pane {
   background: #fff;
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.0175), 0 4px 8px rgba(0, 0, 0, 0.035);
+  box-shadow:
+    0 0 4px rgba(0, 0, 0, 0.0175),
+    0 4px 8px rgba(0, 0, 0, 0.035);
 }
 
 .ModuleTable {
@@ -88,6 +97,14 @@ pre[class*='language-'] {
 .Snippet {
   width: 100%;
   background: white;
+}
+
+.InstallationSnippet {
+  width: 100%;
+}
+
+.InstallationSnippet .highlight {
+  max-width: 100%;
 }
 
 .Snippet__code {

--- a/documentation/src/components/Installation.astro
+++ b/documentation/src/components/Installation.astro
@@ -10,7 +10,9 @@ const { full = false } = Astro.props;
   full ? (
     <>
       <hr class="Rule" />
-      <div class="o-Container o-Container--xs o-Container--center Stage">
+      <div
+        class="InstallationSnippet o-Container o-Container--xs o-Container--center Stage"
+      >
         <h4 class="h6 u-w700 u-mb3">Run the reference implementation</h4>
         <figure class="highlight">
           <pre class="language-shell"><code class="language-shell" data-lang="shell">npm install
@@ -19,7 +21,7 @@ npm run dev --workspace layr-documentation</code></pre>
       </div>
     </>
   ) : (
-    <div class="o-Container--xs">
+    <div class="InstallationSnippet o-Container--xs">
       <figure class="highlight">
         <pre class="language-shell"><code class="language-shell h5 u-mono" data-lang="shell">npm run dev --workspace layr-documentation</code></pre>
       </figure>


### PR DESCRIPTION
## What changed

- add consistent block spacing and padding to Astro, language-tagged, and interactive documentation snippets
- constrain the installation snippet so long commands scroll within the code block instead of widening narrow viewports

## Why

Layr's reset removes default margins and padding from `pre` elements. Documentation snippets therefore rendered flush against their syntax-highlighted backgrounds and adjacent prose. Adding padding also exposed an intrinsic-width overflow in the centered installation snippet, which this change constrains.

## Impact

Code examples have consistent breathing room across Markdown fences, installation commands, and expandable HTML/CSS examples. Narrow layouts remain within the viewport while long lines continue to scroll horizontally.

## Validation

- `npm run build`
- `npm run check`
- `npm run lint`
- `npm test`
- `npm run build --workspace layr-documentation`
- `npm run check --workspace layr-documentation`
- Prettier check for `documentation/global.css`
- `git diff --check`
- visual QA at desktop width and 390px viewport