### PR TITLE
Import Level workspace

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,9 @@ Layr is a live ITCSS reference implementation for teams.
 
 Layr is the renamed continuation of the old Obsidian.css project. It is not currently intended for npm republishing; the goal is to keep a working, inspectable implementation of layered CSS architecture that teams can study, adapt, and run locally.
 
+The reset-only [`level.css`](./level.css) sibling is also preserved as a
+workspace for projects that need only the common browser baseline.
+
 The live documentation site is published at [charliewilco.github.io/layr](https://charliewilco.github.io/layr/).
 
 This project works under the belief that when abstracted most CSS is shockingly similar across projects. More than likely you'll need a type scale, a grid system, spacing utilities, media blocks, sensible default styling for elements (forms, tables, buttons), and a small set of predictable components. Layr keeps those patterns organized as a concrete ITCSS system rather than as a marketing shell.

--- a/level.css/Readme.md
+++ b/level.css/Readme.md
@@ -1,0 +1,28 @@
+# Level.css
+
+Level.css is the historical reset-only sibling of Obsidian.css. It provides a
+small baseline for the box model, default margins, responsive media, forms, and
+code blocks without the rest of the layered framework.
+
+The source at standalone commit
+[`adc4139`](https://github.com/charliewilco/level.css/commit/adc41396f93539ac52fa7bd984d2f0272a3e95d3)
+was moved from
+[`charliewilco/level.css`](https://github.com/charliewilco/level.css) into the
+Layr monorepo so the related implementations can be built and inspected
+together. This workspace preserves the published `level.css@0.1.1` source API,
+but it is not currently intended for npm republishing.
+
+## Build
+
+From the Layr repository root:
+
+```sh
+npm install
+npm run build --workspace level.css
+```
+
+## Usage
+
+```css
+@import "level.css";
+```

--- a/level.css/index.css
+++ b/level.css/index.css
@@ -1,0 +1,146 @@
+/*---------Level.css----------*/
+
+:root {
+  --base-border: 1px;
+}
+
+
+* {
+  margin: 0;
+  padding: 0;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+html {
+  box-sizing: border-box;
+  text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent;
+  font-family: sans-serif;
+}
+
+aside,
+figcaption,
+figure,
+hgroup, /* TODO: Double check if super deprecated */
+main,
+menu,
+details {
+  display: block;
+}
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Media */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+  vertical-align: baseline;
+}
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/* Text Selectors */
+
+abbr[title] {
+  border-bottom-width: calc(var(--base-border) / 2);
+  border-bottom-style: dotted;
+}
+
+b,
+strong {
+  font-weight: bold;
+}
+
+i,
+em {
+  font-style: italic;
+}
+
+a {
+  background-color: transparent;
+  text-decoration: objects;
+}
+
+small {
+  font-size: 80%;
+}
+
+
+/* Content */
+
+figure {
+  margin: 0;
+}
+
+hr {
+  border: 0;
+  height: var(--base-border);
+  overflow: visible;
+}
+
+img {
+  border-style: none;
+  font-style: italic;
+  vertical-align: middle;
+}
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Code Blocks */
+
+pre {
+  overflow: auto;
+}
+
+code,
+pre {
+  font-size: 100%;
+}
+
+/* Forms */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  margin: 0;
+  font-family: inherit;
+}
+
+select,
+button {
+  text-transform: none;
+}
+
+button {
+  overflow: visible;
+}
+
+fieldset {
+  padding: .375rem .75rem .625rem;
+}
+
+legend {
+  color: inherit;
+  display: table;
+  max-width: 100%;
+  padding: 0;
+  white-space: normal;
+}

--- a/level.css/package.json
+++ b/level.css/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "level.css",
+  "private": true,
+  "version": "0.1.1",
+  "description": "A level playing field for browser styling",
+  "main": "index.css",
+  "browser": "dist/level.css",
+  "files": [
+    "index.css",
+    "dist/*"
+  ],
+  "scripts": {
+    "clean": "del ./dist",
+    "dev": "postcss index.css -o dist/level.css --watch",
+    "build": "postcss index.css -o dist/level.css",
+    "check": "npm run lint",
+    "lint": "stylelint index.css"
+  },
+  "keywords": [
+    "normalize",
+    "reset",
+    "css"
+  ],
+  "author": "charles peters <charlespeters42@gmail.com>",
+  "license": "MIT",
+  "repository": "charliewilco/layr",
+  "bugs": {
+    "url": "https://github.com/charliewilco/layr/issues"
+  },
+  "homepage": "https://github.com/charliewilco/layr/tree/main/level.css",
+  "devDependencies": {
+    "autoprefixer": "^10.5.4",
+    "del-cli": "^7.0.0",
+    "postcss": "^8.5.23",
+    "postcss-cli": "^11.0.1",
+    "postcss-custom-properties": "^15.0.1",
+    "stylelint": "^17.14.1"
+  },
+  "browserslist": [
+    "last 1 versions"
+  ],
+  "stylelint": {
+    "rules": {
+      "block-no-empty": true,
+      "color-no-invalid-hex": true,
+      "no-invalid-double-slash-comments": true
+    }
+  }
+}

--- a/level.css/postcss.config.cjs
+++ b/level.css/postcss.config.cjs
@@ -1,0 +1,14 @@
+const autoprefixer = require("autoprefixer");
+const postcssCustomProperties = require("postcss-custom-properties");
+
+module.exports = {
+  map: false,
+  plugins: [
+    postcssCustomProperties({
+      preserve: true,
+    }),
+    autoprefixer({
+      remove: true,
+    }),
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "workspaces": [
         "modern-parker",
         "postcss-parker",
+        "level.css",
         "layr.css",
         "documentation",
         "sass-port"
@@ -90,6 +91,18 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "level.css": {
+      "version": "0.1.1",
+      "license": "MIT",
+      "devDependencies": {
+        "autoprefixer": "^10.5.4",
+        "del-cli": "^7.0.0",
+        "postcss": "^8.5.23",
+        "postcss-cli": "^11.0.1",
+        "postcss-custom-properties": "^15.0.1",
+        "stylelint": "^17.14.1"
       }
     },
     "modern-parker": {
@@ -6369,6 +6382,10 @@
     },
     "node_modules/layr.scss": {
       "resolved": "sass-port",
+      "link": true
+    },
+    "node_modules/level.css": {
+      "resolved": "level.css",
       "link": true
     },
     "node_modules/lightningcss": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "workspaces": [
     "modern-parker",
     "postcss-parker",
+    "level.css",
     "layr.css",
     "documentation",
     "sass-port"


### PR DESCRIPTION
## Summary

- import the tagged `level.css@0.1.1` reset stylesheet from standalone commit `adc4139`
- add Level as a private npm/Turbo workspace using the monorepo's current PostCSS toolchain
- document its relationship to Obsidian.css and Layr

## Why

Level was a reset-only sibling of Obsidian.css and belongs with the renamed Layr continuation. The standalone repository's 2017 Yarn/PostCSS 4 lifecycle is obsolete, so this imports the tagged source unchanged while replacing only its build plumbing.

The repository's later `components` branch is an unrelated React/Next/Turbo experiment and is intentionally excluded.

## Impact

The historical `index.css` source and main entry point remain intact. The generated browser bundle moves from the workspace root to `dist/level.css`, matching the monorepo's clean/build contract. The package is explicitly private to prevent accidental republishing.

This branch was also checked with `git merge-tree` and composes cleanly with the open Pluton workspace PR.

## Validation

- `npm ci` with Node 26.3.0
- `npm run clean`
- `npm run build`
- `npm run check`
- `npm run lint`
- `npm run test`
- `npm audit --audit-level=moderate`
- GitHub Pages-mode documentation build and generated-path check
- Level package dry run and byte comparison against standalone commit `adc4139`
- Prettier check on the new package metadata, configuration, and README
- `git diff --check`