### PR TITLE
[codex] Highlight documentation snippets

### DIFF
--- a/documentation/components/code-block.tsx
+++ b/documentation/components/code-block.tsx
@@ -1,7 +1,12 @@
+import { HighlightedCode } from "./highlighted-code";
+
 export function CodeBlock({ snippet }: { snippet: string }) {
   return (
-    <pre className="Snippet__code">
-      <code className="language-css">{snippet}</code>
-    </pre>
+    <div className="Snippet__sources Snippet__sources--single u-mt4">
+      <section className="Snippet__source">
+        <h4 className="Snippet__heading">CSS</h4>
+        <HighlightedCode code={snippet} language="css" />
+      </section>
+    </div>
   );
 }

--- a/documentation/components/highlighted-code.tsx
+++ b/documentation/components/highlighted-code.tsx
@@ -1,0 +1,18 @@
+import type { CodeLanguage } from "./syntax-highlight";
+import { highlightCode } from "./syntax-highlight";
+
+interface HighlightedCodeProps {
+  code: string;
+  language: CodeLanguage;
+}
+
+export function HighlightedCode({ code, language }: HighlightedCodeProps) {
+  return (
+    <div
+      className="Snippet__code"
+      dangerouslySetInnerHTML={{
+        __html: highlightCode(code, language),
+      }}
+    />
+  );
+}

--- a/documentation/components/snippet.tsx
+++ b/documentation/components/snippet.tsx
@@ -1,37 +1,68 @@
 import type { ComponentType } from "preact";
 import renderToString from "preact-render-to-string";
 
+import { HighlightedCode } from "./highlighted-code";
+
 interface ISnippet {
   component: ComponentType<any>;
   snippet: string;
 }
 
 function formatHtml(html: string) {
-  return html.replace(/></g, ">\n<").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  let indentation = 0;
+
+  return html
+    .replace(/></g, ">\n<")
+    .split("\n")
+    .map(function indentLine(line) {
+      const trimmedLine = line.trim();
+
+      if (trimmedLine.startsWith("</")) {
+        indentation = Math.max(indentation - 1, 0);
+      }
+
+      const formattedLine = `${"  ".repeat(indentation)}${trimmedLine}`;
+      const openingTag = trimmedLine.match(/^<([a-z][\w:-]*)\b[^>]*>/i)?.[1];
+      const isSelfClosing = trimmedLine.endsWith("/>");
+      const closesOnSameLine =
+        openingTag !== undefined &&
+        new RegExp(`</${openingTag}>$`, "i").test(trimmedLine);
+
+      if (openingTag && !isSelfClosing && !closesOnSameLine) {
+        indentation += 1;
+      }
+
+      return formattedLine;
+    })
+    .join("\n");
 }
 
 export function Snippet({ component: Component, snippet }: ISnippet) {
+  const html = formatHtml(renderToString(<Component />));
+
   return (
     <div className="Snippet u-mt4">
       <div className="Snippet__preview u-mb3">
         <Component />
       </div>
-      <details className="u-mb2">
-        <summary className="NavButton u-w700 u-py2">HTML</summary>
-        <pre className="Snippet__code">
-          <code
-            className="language-html"
-            dangerouslySetInnerHTML={{
-              __html: formatHtml(renderToString(<Component />)),
-            }}
-          />
-        </pre>
-      </details>
-      <details>
-        <summary className="NavButton u-w700 u-py2">CSS</summary>
-        <pre className="Snippet__code">
-          <code className="language-css">{snippet}</code>
-        </pre>
+      <details className="Snippet__details">
+        <summary className="Snippet__summary">
+          <span>View source</span>
+          <span className="Snippet__summaryMeta">HTML + CSS</span>
+        </summary>
+        <div
+          className="Snippet__sources"
+          role="group"
+          aria-label="Example source code">
+          <section className="Snippet__source">
+            <h4 className="Snippet__heading">HTML</h4>
+            <HighlightedCode code={html} language="html" />
+          </section>
+          <section className="Snippet__source">
+            <h4 className="Snippet__heading">CSS</h4>
+            <HighlightedCode code={snippet} language="css" />
+          </section>
+        </div>
       </details>
     </div>
   );

--- a/documentation/components/syntax-highlight.ts
+++ b/documentation/components/syntax-highlight.ts
@@ -1,0 +1,15 @@
+import { createHighlighter } from "shiki";
+
+export type CodeLanguage = "css" | "html";
+
+const highlighter = await createHighlighter({
+  langs: ["css", "html"],
+  themes: ["github-light"],
+});
+
+export function highlightCode(code: string, language: CodeLanguage) {
+  return highlighter.codeToHtml(code.trim(), {
+    lang: language,
+    theme: "github-light",
+  });
+}

--- a/documentation/global.css
+++ b/documentation/global.css
@@ -1,11 +1,5 @@
-code[class*="language-"],
-pre[class*="language-"] {
-  font-family: "SF Mono", "Source Code Pro", "Menlo", monospace !important;
-}
-
 pre.astro-code,
-pre[class*="language-"],
-.Snippet__code {
+pre[class*="language-"] {
   margin-block: var(--base-spacing);
   padding: var(--base-spacing);
 }
@@ -99,6 +93,82 @@ pre[class*="language-"],
   background: white;
 }
 
+.Snippet__details {
+  overflow: hidden;
+  border: 1px solid #d8dee4;
+  border-radius: 0.375rem;
+}
+
+.Snippet__summary {
+  padding: 0.75rem 0.875rem;
+  color: #147aab;
+  background: #f6f8fa;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.Snippet__summaryMeta {
+  float: right;
+  color: #6e7781;
+  font-family: "SF Mono", "Source Code Pro", "Menlo", monospace;
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+}
+
+.Snippet__details[open] .Snippet__summary {
+  border-bottom: 1px solid #d8dee4;
+}
+
+.Snippet__sources {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid #d8dee4;
+  border-radius: 0.375rem;
+  background: #d8dee4;
+  gap: 1px;
+}
+
+.Snippet__details .Snippet__sources {
+  border: 0;
+  border-radius: 0;
+}
+
+.Snippet__source {
+  min-width: 0;
+  background: #fff;
+}
+
+.Snippet__heading {
+  margin: 0;
+  padding: 0.625rem 0.875rem;
+  border-bottom: 1px solid #d8dee4;
+  color: #57606a;
+  background: #f6f8fa;
+  font-family: "SF Mono", "Source Code Pro", "Menlo", monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1;
+}
+
+.Snippet__code {
+  max-height: 22rem;
+  overflow: auto;
+}
+
+.Snippet__code .shiki {
+  min-width: max-content;
+  margin: 0;
+  padding: 1rem;
+  background: #fff !important;
+  font-family: "SF Mono", "Source Code Pro", "Menlo", monospace;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+}
+
 .InstallationSnippet {
   width: 100%;
 }
@@ -107,11 +177,10 @@ pre[class*="language-"],
   max-width: 100%;
 }
 
-.Snippet__code {
-  display: block;
-  height: 100%;
-  max-height: 25rem;
-  overflow-y: scroll;
+@media (min-width: 48rem) {
+  .Snippet__sources:not(.Snippet__sources--single) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .Logo {

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -14,7 +14,8 @@
     "astro": "^7.1.3",
     "layr.css": "^3.1.0",
     "preact": "^10.29.7",
-    "preact-render-to-string": "^6.7.0"
+    "preact-render-to-string": "^6.7.0",
+    "shiki": "^4.3.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "astro": "^7.1.3",
         "layr.css": "^3.1.0",
         "preact": "^10.29.7",
-        "preact-render-to-string": "^6.7.0"
+        "preact-render-to-string": "^6.7.0",
+        "shiki": "^4.3.1"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",


### PR DESCRIPTION
## Summary

The documentation demos exposed their HTML and CSS as separate disclosure blocks. Opening either block showed escaped plain text without syntax highlighting, and comparing the two sources required moving between vertically stacked panels.

The renderer now presents one compact native **View source** disclosure. When opened, it shows build-time highlighted HTML and CSS side by side on wider screens and stacked on narrow screens. CSS-only examples use the same source-panel presentation.

## Root cause

The snippet component added `language-html` and `language-css` classes to dynamically rendered code, but no runtime or build-time highlighter processed those nodes. The two independent `<details>` elements also treated related source as separate controls, while the generated HTML only inserted line breaks without readable indentation.

## Changes

- Add a small shared Shiki renderer for HTML and CSS.
- Format server-rendered example markup with readable nesting before highlighting it.
- Replace the separate HTML and CSS disclosures with one compact source disclosure.
- Add responsive source panels with bounded scrolling and explicit language labels.
- Reuse the highlighted source panel for CSS-only examples.
- Keep syntax highlighting build-time only; the generated component page includes no client scripts.

## Validation

Validated with Node 26.5.0 and npm 11.17.0:

- `npx prettier --check ...`
- `npm run check`
- `npm run lint`
- `npm run test` — 8 tests passed
- `npm run build` — 12 documentation pages built
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- GitHub Pages-mode Astro build and `/layr` generated-path check
- `git diff --check`
- Browser QA at 1280px and 390px widths, including expanded source panels and page-level overflow
